### PR TITLE
Add support for async functions and functions with default arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ const functionArguments = require('function-arguments')
 ```js
 var fnArgs = require('function-arguments')
 
-console.log(fnArgs(function (a, b, c) {})) // => [ 'a', 'b', 'c' ]
-console.log(fnArgs(function named (a , b, c) {})) // => [ 'a', 'b', 'c' ]
+console.log(fnArgs(function (a, b, c = 42) {})) // => [ 'a', 'b', 'c' ]
+console.log(fnArgs(function named (a , b, c = 42) {})) // => [ 'a', 'b', 'c' ]
 
 console.log(fnArgs(a => {})) // => [ 'a' ]
-console.log(fnArgs((a, b) => {})) // => [ 'a', 'b' ]
+console.log(fnArgs((a, b = 42) => {})) // => [ 'a', 'b' ]
 
-console.log(fnArgs(function * (a ,b, c) {})) // => [ 'a', 'b', 'c' ]
-console.log(fnArgs(function * named (a ,b, c) {})) // => [ 'a', 'b', 'c' ]
+console.log(fnArgs(function * (a, b, c = 42) {})) // => [ 'a', 'b', 'c' ]
+console.log(fnArgs(function * named (a, b, c = 42) {})) // => [ 'a', 'b', 'c' ]
+
+console.log(fnArgs(async function (a, b, c = 42) {})) // => [ 'a', 'b', 'c' ]
+console.log(fnArgs(async function named (a , b, c = 42) {})) // => [ 'a', 'b', 'c' ]
 ```
 
 ### Works when using comments

--- a/index.js
+++ b/index.js
@@ -56,6 +56,8 @@ module.exports = function functionArguments (fn) {
 
   var match = fnStr.match(/\(([\s\S]*)\)/)
   return match ? match[1].split(',').map(function (param) {
+    var idx
+    if ((idx = param.indexOf('=')) !== -1) param = param.slice(0, idx)
     return param.trim()
   }) : []
 }

--- a/test.js
+++ b/test.js
@@ -51,3 +51,18 @@ test('should get arguments of an arrow and generator functions', function (done)
   test.deepEqual(fnArgs(function * named (a, b, c) {}), ['a', 'b', 'c'])
   done()
 })
+
+test('should get arguments of an async functions', function (done) {
+  test.deepEqual(fnArgs(async function (a, b, c) {}), ['a', 'b', 'c'])
+  test.deepEqual(fnArgs(async function named (a, b, c) {}), ['a', 'b', 'c'])
+  done()
+})
+
+test('should get array with arguments names from function with default parameters', function (done) {
+  test.deepEqual(fnArgs(function (a, b = '=foo', c = 42) {}), ['a', 'b', 'c'])
+  test.deepEqual(fnArgs(function named (a, b = '=foo', c = 42) {}), ['a', 'b', 'c'])
+  test.deepEqual(fnArgs((a, b = '=foo', c = 42) => {}), ['a', 'b', 'c'])
+  test.deepEqual(fnArgs(function * (a, b = '=foo', c = 42) {}), ['a', 'b', 'c'])
+  test.deepEqual(fnArgs(function * named (a, b = '=foo', c = 42) {}), ['a', 'b', 'c'])
+  done()
+})


### PR DESCRIPTION
Hello!

I use `function-arguments`, but in ECMAScript 6 was added support for the default parameters and `async`-functions. I added the possibility of working correctly with such functions